### PR TITLE
Run default models

### DIFF
--- a/1_prep/src/build_model_config.R
+++ b/1_prep/src/build_model_config.R
@@ -43,7 +43,7 @@ build_nldas_model_config <- function(nml_list,
     site_id = sapply(obs_rds,
                      function(x){str_match(x, '(?:[^_]*\\_){3}([^.]*)')[2]},
                      simplify = TRUE),
-    obs_fl = basename(obs_rds),
+    obs_fl = obs_rds,
     obs_fl_hash =  sapply(obs_rds, tools::md5sum)
   )
 

--- a/2_run.R
+++ b/2_run.R
@@ -1,38 +1,27 @@
-source('2_run/src/run_glm3.R')
+source('3_calibrate/src/calibration_utils.R')
 
 p2 <- list(
 
-  ##### NLDAS model runs #####
-  # Function will generate file
-  # but return a tibble that includes that filename and its hash
-  # put simulation directories in sub-directory for easy deletion
   tar_target(
-    p2_nldas_glm_uncalibrated_runs,
+    p2_nldas_glm_default_runs,
     {
-      # check mapping to ensure is correct
-      tar_assert_identical(p1_nldas_model_config$site_id, p1_nldas_nml_objects$morphometry$lake_name, "p1_nldas_nml_objects site id doesn't match p1_nldas_model_config site id")
-      run_glm3_model(
-        sim_dir = '2_run/tmp/nldas_simulations',
-        nml_obj = p1_nldas_nml_objects,
-        model_config = p1_nldas_model_config,
-        export_fl_template = '2_run/tmp/GLM_%s_%s_%s.feather')
-    },
-    packages = c('retry','glmtools', 'GLM3r'),
-    pattern = map(p1_nldas_model_config, p1_nldas_nml_objects)),
+      # check mapping to ensure model configuration matches nml object list order
+      tar_assert_identical(p1_nldas_model_config$site_id,
+                           p1_nldas_nml_objects$morphometry$lake_name,
+                           "p1_nldas_nml_objects site id doesn't match p1_nldas_model_config site id")
 
-  # For bundling of results by lake in 3_extract
-  # Group model runs by lake id
-  # Discard the glm diagnostics so they don't trigger rebuilds
-  # even when the export_fl_hash is unchanged
-  # Filter to successful model runs
-  tar_target(
-    p2_nldas_glm_uncalibrated_run_groups,
-    p2_nldas_glm_uncalibrated_runs %>%
-      select(site_id, driver, time_period, driver_start_date, driver_end_date,
-             export_fl, export_fl_hash, glm_success) %>%
-      filter(glm_success) %>%
-      group_by(site_id) %>% # Group by site_id for creating export files
-      tar_group(),
-    iteration = "group"
-  )
+      # check mapping to ensure model configuration matches nml met file
+      tar_assert_identical(basename(p1_nldas_model_config$meteo_fl),
+                           p1_nldas_nml_objects$meteorology$meteo_fl,
+                           "p1_nldas_nml_objects meteo file doesn't match p1_nldas_model_config meteo file")
+
+      run_glm_cal(
+        nml_obj = p1_nldas_nml_objects,
+        sim_dir = '2_run/out',
+        cal_parscale = c('cd' = 0.0001, 'sw_factor' = 0.02, 'Kw' = 0.01),
+        model_config = p1_nldas_model_config,
+        optimize = FALSE)
+    },
+    pattern = map(p1_nldas_model_config, p1_nldas_nml_objects))
+
 )

--- a/2_run.R
+++ b/2_run.R
@@ -20,7 +20,7 @@ p2 <- list(
         sim_dir = '2_run/out',
         cal_parscale = c('cd' = 0.0001, 'sw_factor' = 0.02, 'Kw' = 0.01),
         model_config = p1_nldas_model_config,
-        optimize = FALSE)
+        calibrate = FALSE)
     },
     pattern = map(p1_nldas_model_config, p1_nldas_nml_objects))
 

--- a/3_calibrate.R
+++ b/3_calibrate.R
@@ -21,7 +21,8 @@ p3 <- list(
         nml_obj = p1_nldas_nml_objects,
         sim_dir = '3_calibrate/out',
         cal_parscale = c('cd' = 0.0001, 'sw_factor' = 0.02, 'Kw' = 0.01),
-        model_config = p1_nldas_model_config)
+        model_config = p1_nldas_model_config,
+        optimize = TRUE)
     },
     # packages = c('retry','glmtools', 'GLM3r'), # not currently using `retry`
     pattern = map(p1_nldas_model_config, p1_nldas_nml_objects))

--- a/3_calibrate/src/calibration_utils.R
+++ b/3_calibrate/src/calibration_utils.R
@@ -18,7 +18,7 @@ run_glm_cal <- function(nml_obj,
   time_period <- model_config$time_period
   driver <- model_config$driver
   raw_meteo_fl <- model_config$meteo_fl
-  cal_data_fl <- model_config$obs_fl
+  raw_obs_fl <- model_config$obs_fl
 
   # Define simulation start and stop dates based on burn-in and burn-out periods
   sim_start <- as.character(model_config$burn_in_start)
@@ -31,10 +31,6 @@ run_glm_cal <- function(nml_obj,
   # copy meteo data to sim_lake_dir
   sim_meteo_filename <- basename(raw_meteo_fl)
   file.copy(from = raw_meteo_fl, to = sim_lake_dir)
-
-  # # copy obs data to sim_lake_dir
-  # sim_obs_filename <- basename(raw_meteo_fl)
-  # file.copy(from = raw_meteo_fl, to = sim_lake_dir)
 
   # set parameters
   # write nml file, specifying meteo file and start and stop dates:
@@ -51,8 +47,8 @@ run_glm_cal <- function(nml_obj,
   # get starting values for params that will be modified
   cal_starts <- sapply(cal_params, FUN = function(x) glmtools::get_nml_value(nml_obj, arg_name = x))
 
-  # build obs data file path
-  tmp_cal <- file.path('1_prep/out', cal_data_fl)
+  # # build obs data file path
+  # tmp_cal <- file.path('1_prep/out', cal_data_fl)
 
   if(optimize == T) {
 
@@ -69,7 +65,7 @@ run_glm_cal <- function(nml_obj,
     # compare_file, sim_dir
     out <- optim(fn = set_eval_glm, par = cal_starts,
                  control = list(parscale = parscale),
-                 caldata_fl = tmp_cal,
+                 caldata_fl = raw_obs_fl,
                  sim_dir = sim_lake_dir,
                  nml_obj = nml_obj)
 
@@ -79,7 +75,7 @@ run_glm_cal <- function(nml_obj,
 
     # run the model "as is"
     rmse <- set_eval_glm(par = cal_starts,
-                        caldata_fl = tmp_cal,
+                        caldata_fl = raw_obs_fl,
                         sim_dir = sim_lake_dir,
                         nml_obj = nml_obj)
 

--- a/_targets.R
+++ b/_targets.R
@@ -12,6 +12,8 @@ tar_option_set(packages = c('tidyverse',
                             'ggplot2',
                             'glmtools'))
 
+# tar_option_set(debug = "p2_nldas_glm_default_runs")
+
 source('1_prep.R')
 source('2_run.R')
 # source('3_calibrate.R')

--- a/_targets.R
+++ b/_targets.R
@@ -13,12 +13,11 @@ tar_option_set(packages = c('tidyverse',
                             'glmtools'))
 
 source('1_prep.R')
-# source('2_run.R')
-source('3_calibrate.R')
+source('2_run.R')
+# source('3_calibrate.R')
 # source('3_extract.R')
 # source('4_visualize.R')
 # source('5_evaluate.R')
 
 # Return the complete list of targets
-
-c(p1, p3)#, p4, p5)
+c(p1, p2)#p3, p4, p5)


### PR DESCRIPTION
## Overview
In discussing the results of the MO model calibration (#7), Jordan and I agreed that the current calibration needs improvement. As part of the calibration improvement process we agreed that it would be helpful to have a phase that runs the default models so we could compare the calibrated models to the uncalibrated.

This PR does two things:
* Adds in a new phase for running the default MO model configurations before calibration
* Fixes a personally annoying file naming inconsistency in `p1_nldas_model_config`


This pipeline takes < 2 min to run locally. Closes issue #8.

## Summary of changes
* Adds in a new phase for running the default MO model configurations before calibration
   *  I did this by adding a control structure to `run_glm_cal ` in `3_calibration/src`. I did this because I wanted to make it clear that we were running the same GLM3 executable when calibrating and when running the deafult model config.
* Fixes a personally annoying file naming inconsistency in `p1_nldas_model_config`
  * The `obs_fl` field in `p1_nldas_model_config` did not originally contain the full file path. I corrected this so that the `obs_fl` field and the `meteo_fl` field will look similar in `p1_nldas_model_config`.


## Verification

To verify my results, I ran a file compare on the `glm3.nml` that the pipeline writes when setting up the model and the `glm3_uncal.nml` that pipeline writes after running the model. I expected these files to mostly match, with the `glm3_uncal.nml` containing an additional `&results` entry.

Screenshot of a file compare between two files in `nhdhr_102216470_NLDAS_1980_2021`:

![image](https://user-images.githubusercontent.com/15007294/179257508-293f767c-bc54-4cfc-8551-00a5091d79af.png)


## Next steps
I'm going to work on issue #11,which shouldn't conflict with this PR.

