### PR TITLE
Add evaluation method for final model calibration

### DIFF
--- a/3_calibrate.R
+++ b/3_calibrate.R
@@ -20,13 +20,28 @@ p3 <- list(
 
   tar_target(
     p3_nldas_glm_cal_tibble,
-    tibble(
-      model_file = p3_nldas_glm_calibration_runs_nml,
-      model_file_hash = tools::md5sum(p3_nldas_glm_calibration_runs_nml),
-      run_type = 'calibrated',
-      time_period = p1_nldas_time_period,
-      model_group = NULL
-    )
+    {
+      tibble(
+        model_file = p3_nldas_glm_calibration_runs_nml,
+        model_file_hash = tools::md5sum(p3_nldas_glm_calibration_runs_nml),
+        run_type = 'calibrated',
+        time_period = p1_nldas_time_period
+      ) %>%
+        mutate(
+          filter_col = str_extract(model_file,
+                              '(?<=.out/)(.*)(?=/nhdhr)'),
+          site_id = str_extract(model_file,
+                                '(nhdhr.*)(?=_NLDAS)')
+        ) %>%
+        # add `p1_lake_to_univ_mo_xwalk_df`  to capture lake name
+        left_join(., p1_lake_to_univ_mo_xwalk_df) %>%
+        # add `p1_nldas_model_config`  to capture observed data src and hash
+        left_join(p1_nldas_model_config)  %>%
+        select(site_id, `Lake Name`, run_type, filter_col, time_period,
+               model_file, model_file_hash,
+               obs_fl, obs_fl_hash)
+    }
+
   )
 
 )

--- a/4_extract.R
+++ b/4_extract.R
@@ -6,13 +6,13 @@ p4 <- list(
     extract_glm_output(p2_nldas_glm_uncal_tibble,
                        out_template = '4_extract/out/%s/%s.feather'),
     format = 'file'
-  )#,
-#
-#   tar_target(
-#     p4_extract_cal_models_feather,
-#     extract_glm_output(p3_nldas_glm_cal_tibble,
-#                        out_template = '4_extract/out/%s/%s/%s.feather'),
-#     format = 'file'
-#   )
+  ),
+
+  tar_target(
+    p4_extract_cal_models_feather,
+    extract_glm_output(p3_nldas_glm_cal_tibble,
+                       out_template = '4_extract/out/%s/%s/%s.feather'),
+    format = 'file'
+  )
 
 )

--- a/4_extract/src/extract_model_data.R
+++ b/4_extract/src/extract_model_data.R
@@ -39,18 +39,8 @@ extract_glm_output <- function(glm_model_tibble,
                           str_extract(current_run$model_file, '(nhdhr).*(?=\\/output)'))
     }
 
-    path_out <- str_extract(file_out, '.+?(?=nhdhr)')
+    path_out <- str_extract(file_out, '.+?(?=/nhdhr)')
     if(!dir.exists(path_out)) dir.create(path_out, recursive = TRUE)
-
-
-    # check for calibration-specific subfolder
-    # create if it does not exist
-    if(current_run$run_type == 'calibrated') {
-      model_subfolder <- str_extract(current_run$model_file,
-                                     '(?<=out\\/).*(?=\\/nhdhr)')
-      path_out <- file.path(path_out, model_subfolder)
-      if(!dir.exists(path_out)) dir.create(path_out)
-    }
 
     model_feather <- str_extract(current_run$model_file, '(nhdhr).*(?=\\/output)') %>%
       paste0(., '.feather')

--- a/5_eval.R
+++ b/5_eval.R
@@ -1,0 +1,17 @@
+
+p5 <- list(
+  tar_target(
+    p5_calibration_reporting_params,
+    p3_nldas_glm_cal_tibble %>% filter(filter_col == 'all'),
+  ),
+
+  tar_render_rep(
+    p5_calibration_report,
+    '5_eval_calibration_template.Rmd',
+    params = tibble(
+      par = p5_calibration_reporting_params,
+      output_file = sprintf('5_eval/out/%s_%s_data.html',
+                            par$site_id, par$filter_col)
+    )
+  )
+)

--- a/5_eval_calibration_template.Rmd
+++ b/5_eval_calibration_template.Rmd
@@ -1,0 +1,146 @@
+---
+title: "Missouri Model Review"
+author: "Julie Padilla"
+date: "`r Sys.Date()`"
+# output: html_document
+output_format: html_document
+params:
+  par: "default value"
+---
+
+```{r libraries, include = FALSE}
+library(tidyverse)
+library(arrow)
+library(glmtools)
+library(targets)
+library(tidyr)
+library(lubridate)
+library(kableExtra)
+```
+
+```{r targets, include = FALSE}
+lake_name <- params$par$`Lake Name`
+
+site_id <- params$par$site_id
+
+data_type <- params$par$filter_col
+```
+
+This is an output report for the calibrated `r lake_name` [GLM](https://aed.see.uwa.edu.au/research/models/glm/) model. This model was calibrated using `r data_type` data.
+
+
+```{r setup, include = FALSE}
+
+# ID file paths for inputs
+model_folder <- sprintf('3_calibrate/out/%s/%s_NLDAS_1980_2021', 
+                        data_type, site_id)
+
+model_nml <- glmtools::read_nml(nml_file = file.path(model_folder, 'output', 'glm_cal.nml'))
+
+# field_folder <- params$par$label
+
+nc_file <- file.path(model_folder, get_nml_value(model_nml, "out_dir"), paste0(get_nml_value(model_nml, "out_fn"), '.nc'))
+
+field_file <- params$par$obs_fl
+  # file.path(field_folder, paste('field_data_', site_id, '.rds', sep = ''))
+
+```
+
+# Observed Data Summary
+```{r summarize-data, warning=FALSE}
+# subset observed data to modeled values
+model_obs <- glmtools::resample_to_field(nc_file, field_file) %>%
+  dplyr::mutate(year = year(DateTime), month = month(DateTime))
+
+# document unique profiles by month and year
+model_obs %>%
+  dplyr::group_by(year, month) %>%
+  dplyr::summarize(n_profile = n_distinct(DateTime)) %>%
+  tidyr::pivot_wider(names_from = year, values_from = n_profile) %>%
+  dplyr::arrange(month) %>%
+  kableExtra::kbl() %>%
+  kable_styling()
+```
+
+# Calibration Results Overview
+
+```{r cal-overview}
+rmse_val <- round(glmtools::get_nml_value(model_nml, 'rmse'), 2)
+cal_vals <- round(glmtools::get_nml_value(model_nml, 'values'), 4)
+names(cal_vals) <- c('cd', 'sw_factor', 'Kw')
+
+print(paste0('rmse = ', rmse_val))
+print(cal_vals)
+
+```
+
+# Model-to-Data Comparisons
+
+## Heatmap
+```{r heatmap-and-rmse, warning = FALSE}
+## Time series comparison
+plot_var_compare(nc_file, field_file,
+                 precision = 'days', var_name = 'temp') + ## makes a plot!
+  ggtitle('Cal Model') +
+  theme(plot.title = element_text(hjust = 0.5))
+```
+
+```{r rmse-review, warning = FALSE}
+# define RMSE function
+calc_rmse <- function(mod, obs) {
+  # RMSE = √[ Σ(Pi – Oi)2 / n ]
+  mse <- mean((obs - mod)^2, na.rm = T)
+  sqrt(mse)
+}
+
+# calc RMSE by month
+rmse_vals <- model_obs %>%
+  group_by(year, month) %>%
+  summarize(rmse = round(calc_rmse(Modeled_temp, Observed_temp), 2))
+
+# generate tabular summary
+rmse_vals %>%
+  pivot_wider(names_from = year, values_from = rmse) %>%
+  arrange(month) %>%
+  kbl() %>%
+  kable_styling()
+
+# plot by year
+rmse_vals %>%
+  arrange(year, month) %>%
+  mutate(year = as.factor(year)) %>%
+  ggplot(., aes(x = month, y = rmse, group = year, color = year)) +
+  geom_point() +
+  geom_hline( yintercept = 1.5) +
+  # geom_line() +
+  facet_wrap(~ year)
+
+# plot by month
+rmse_vals %>%
+  arrange(year, month) %>%
+  ggplot(., aes(x = year, y = rmse)) +
+  geom_point() +
+  geom_hline( yintercept = 1.5) +
+  facet_wrap(~ month)
+```
+
+
+## One-to-one Plot
+
+```{r one-to-one}
+# subset data
+model_obs <- resample_to_field(nc_file, field_file) %>%
+  mutate(month = month(DateTime))
+
+# plot 1-to-1 by month
+ggplot(model_obs,
+       aes(x = Observed_temp, y = Modeled_temp, color = Depth)) +
+  geom_point() +
+  geom_abline(intercept = 0, slope = 1) +
+  coord_fixed(ratio = 1) +
+  facet_wrap( ~ month) +
+  ggtitle(paste(lake_name, ' - 1:1 by Month', sep = '')) +
+  theme(plot.title = element_text(hjust = 0.5))
+```
+
+

--- a/_targets.R
+++ b/_targets.R
@@ -19,8 +19,9 @@ tar_option_set(packages = c('arrow',
 
 source('1_prep.R')
 source('2_run.R')
-# source('3_calibrate.R') # skipping the calibration step in this phase
+source('3_calibrate.R')
 source('4_extract.R')
+source('5_eval.R')
 
-c(p1, p2, p4)#, p3, p4)
+c(p1, p2, p3, p4, p5)
 


### PR DESCRIPTION
## Overview
I have added a new phase to the pipeline that creates a simple calibration report for each reservoir in the final model calibration. This reporting template was modified based on an earlier template that was manually populated outside the pipeline.

I tested a few different ways and the improvements were nominal:

site_id | Lake Name | uncal | all data | 5_km_clip | 10_km_clip | 15_km_clip
-- | -- | -- | -- | -- | -- | --
nhdhr_120032269 | Lake Ozark - Bagnell Dam | 6.64 | 1.992 | 1.907 | 1.907 | 1.957
nhdhr_120031146 | Truman Res. | 3.36 | 2.071 | 1.920 | 1.920 | 1.920
nhdhr_120032180 | Mark Twain Lake | 3.63 | 2.026 | 2.021 | 2.021 | 2.021
nhdhr_106716325 | Lake Stockton | 3.47 | 2.280 | 2.200 | 2.200 | 2.199
nhdhr_120032495 | Wapapello Lake | 4.88 | 2.236 | 2.237 | 2.236 | 2.236
nhdhr_102216470 | Pomme De Terre Lake | 3.22 | 2.749 | 2.558 | 2.787 | 2.748
nhdhr_120032884 | Table Rock Lake | 3.41 | 2.910 | 2.938 | 2.929 | 2.929
nhdhr_120032533 | Bull Shoals Lake | 4.26 | 3.676 | 3.835 | 3.445 | 3.597

For this reason, we decided to use all the available data for each individual lake calibration.


## Summary of Major Changes
* Inclusion of a new phase and associated files: `5_eval` - that dynamically branches over a single Rmd template (`5_eval_calibration_template.Rmd`)
* Updates to `p3_nldas_glm_cal_tibble` for use in reporting as part of `5_eval`

## Verification of Changes

I have been able to successfully run this pipeline and create the expected files. After running this pipeline you should see 8 html files in `5_eval/out`: one for each calibrated model. See screenshots below.

![image](https://user-images.githubusercontent.com/15007294/192386595-11409111-0900-461e-af14-a9d60117b5e8.png)

## Notes on the pipeline
* Phase 4 (`4_extract`) comes before `5_eval` this is because we wanted to get collaborators draft file extractions as soon as possible. In retrospect, it should probably come after the evaluation phase so that we only extract the files that we want. Right now this pipeline extracts files from all models.
* This is my first time using `tar_render_rep` to dynamically map over one template. In theory this should be a file target because it produces 8 html files, but `tar_render_rep` actually returns a list of 16 file names (one for each populated template and the rmd template name [which is repeated 8 times]). Setting `format = 'file'` returns an error. I did check that changes to the template do result in rebuilds.
