### PR TITLE
Fix name convention for calibrated model results

### DIFF
--- a/2_run.R
+++ b/2_run.R
@@ -24,6 +24,7 @@ p2 <- list(
   tar_target(
     p2_nldas_glm_uncal_tibble,
     tibble(
+      model_type = 'GLM',
       model_file = p2_nldas_glm_default_runs_nml,
       model_file_hash = tools::md5sum(p2_nldas_glm_default_runs_nml),
       run_type = 'uncalibrated',

--- a/3_calibrate.R
+++ b/3_calibrate.R
@@ -39,7 +39,7 @@ p3 <- list(
         # add `p1_nldas_model_config`  to capture observed data src and hash
         left_join(p1_nldas_model_config)  %>%
         select(site_id, `Lake Name`, run_type, filter_col, time_period,
-               model_file, model_file_hash,
+               model_type, model_file, model_file_hash,
                obs_fl, obs_fl_hash)
     }
 

--- a/3_calibrate.R
+++ b/3_calibrate.R
@@ -22,6 +22,7 @@ p3 <- list(
     p3_nldas_glm_cal_tibble,
     {
       tibble(
+        model_type = 'GLM',
         model_file = p3_nldas_glm_calibration_runs_nml,
         model_file_hash = tools::md5sum(p3_nldas_glm_calibration_runs_nml),
         run_type = 'calibrated',

--- a/4_extract/src/extract_model_data.R
+++ b/4_extract/src/extract_model_data.R
@@ -14,10 +14,8 @@ extract_glm_output <- function(glm_model_tibble,
       driver_start_date = as.Date(sprintf('%s-01-01', model_years[1])), # set based on user-defined modeling period
       driver_end_date = as.Date(sprintf('%s-12-31', model_years[2])) # set based on user-defined modeling period
     )
-  # browser()
 
   out_paths <- purrr::pmap(glm_model_tibble, function(...) {
-    # browser()
 
     current_run <- tibble(...)
 


### PR DESCRIPTION
## Overview
This PR addresses the model extraction file name mismatch identified by Lindsay in #17. Merging this PR closes #17.

## Summary of changes
This is a pretty small PR. The bulk of the work happens in [`4_extract/src/extract_model_data.R`](https://github.com/USGS-R/lake-temperature-missouri-models/compare/main...padilla410:fix-name-convention?expand=1#diff-dd0e6d5c3ed6ca855be90b360e144f9938c93534d2d1e2bb66acef33961e18f5) which is where the names of the feather files are generated.

While I was adjusting the naming pattern I noticed a duplicate step, so I took it out - I was creating `outfile` and `file_out` which both are full file paths for the feather files.

Upstream of `4_extract` I made minor edits to tibbles that are required to extract the data. These changes were made so that I could have all of the components of the desired naming convention in the tibbles that feed into `4_extract`.

## Verification

A valid targets pipeline that highlights the targets of interest (`p4_extract_uncal_models_feather` and `p4_extract_cal_models_feather`):
![image](https://user-images.githubusercontent.com/15007294/195724695-8829672a-be3a-4af2-8f85-66d954259ed4.png)

Verification of the new naming convention:
![image](https://user-images.githubusercontent.com/15007294/195724847-7d1fae0c-a5ba-46d0-a450-93bf1257a840.png)

![image](https://user-images.githubusercontent.com/15007294/195724875-4a055b5d-8e88-4da1-8761-3e007cc171c4.png)

Verification that the reporting templates are updating (I also spot checked the contents):
![image](https://user-images.githubusercontent.com/15007294/195725124-2ea2185e-19b0-4a12-9408-2a13b6ff79f8.png)


## Requested review
Lindsay, I'm tagging you for a quick review. I thought about merging this myself, but wanted to make sure that the naming convention matched what you needed.


